### PR TITLE
fix local parameter name of PhotoLibrary.imageFromImage

### DIFF
--- a/www/PhotoLibrary.js
+++ b/www/PhotoLibrary.js
@@ -16,7 +16,7 @@ PhotoLibrary.imageFromImage = function (imgElm, successCallback, failureCallback
   canvas.height = imgElm.naturalHeight * ratio
   ctx.scale(ratio, ratio)
 
-  ctx.drawImage(imgElm, 0, 0, img.naturalWidth, img.naturalHeight)
+  ctx.drawImage(imgElm, 0, 0, imgElm.naturalWidth, imgElm.naturalHeight)
 
   return PhotoLibrary.imageFromCanvas(canvas)
 }


### PR DESCRIPTION
Hello!
Probably a modified mistake occurred when support save video to photo library.
 https://github.com/buunguyen/cordova-photo-library/commit/c509b9e9f7a22621b0e43317f0d8ee1f16935870
